### PR TITLE
Calling "Input.ShowOSD" instead of "Input.Info"

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <div class="center">
       <button type="button" class="small" id="stop">■</button>
       <button type="button" class="small" id="home">⌂</button>
-      <button type="button" class="small" id="info"></button>
+      <button type="button" class="small" id="player"></button>
       <button type="button" class="small" id="back">↩</button>
       <p>
         <label for="range" data-l10n-id="volume"></label>

--- a/js/app.js
+++ b/js/app.js
@@ -307,8 +307,8 @@ function start() {
     callKodi('Input.Back', undefined, callKodiErrorHandler);
   });
 
-  inputs.info = new Input('info', 'click', function () {
-    callKodi('Input.Info', undefined, callKodiErrorHandler);
+  inputs.info = new Input('player', 'click', function () {
+    callKodi('Input.ShowOSD', undefined, callKodiErrorHandler);
   });
 
   inputs.select = new Input('select', 'click', function () {


### PR DESCRIPTION
Calling "Input.ShowOSD" instead of "Input.Info" may be more useful.
For example, with ShowOSD you can access to audio and subtitles settings. This is currently not possible with Kodi Remote (great app by the way).
